### PR TITLE
Preferred and denied package prefixes

### DIFF
--- a/src/Westermo.Nuget.ReadThroughCache/Configuration/RemotePackageRepositoryConfigurationItem.cs
+++ b/src/Westermo.Nuget.ReadThroughCache/Configuration/RemotePackageRepositoryConfigurationItem.cs
@@ -1,8 +1,40 @@
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+
 namespace Westermo.Nuget.ReadThroughCache.Configuration;
 
 public class RemotePackageRepositoryConfigurationItem
 {
+    private readonly string[] m_preferredPackagePrefixes = Array.Empty<string>();
+    private readonly string[] m_deniedPackagePrefixes = Array.Empty<string>();
+
     public string Name { get; init; } = null!;
     public string ServiceIndex { get; init; } = null!;
     public int? Version { get; init; } = 3;
+
+    public string[] PreferredPackagePrefixes
+    {
+        get => m_preferredPackagePrefixes;
+        init
+        {
+            PreferredPackagePrefixesAsRegex = value.Select(v => new Regex(v, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase))
+                                                   .ToArray();
+            m_preferredPackagePrefixes = value;
+        }
+    }
+
+    public string[] DeniedPackagePrefixes
+    {
+        get => m_deniedPackagePrefixes;
+        init
+        {
+            DeniedPackagePrefixesAsRegex = value.Select(v => new Regex(v, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase))
+                                                .ToArray();
+            m_deniedPackagePrefixes = value;
+        }
+    }
+
+    public Regex[] PreferredPackagePrefixesAsRegex { get; private set; } = Array.Empty<Regex>();
+    public Regex[] DeniedPackagePrefixesAsRegex { get; private set; } = Array.Empty<Regex>();
 }

--- a/src/Westermo.Nuget.ReadThroughCache/Program.cs
+++ b/src/Westermo.Nuget.ReadThroughCache/Program.cs
@@ -61,6 +61,8 @@ public class Program
             configurationOutput.AppendLine($"        ServiceIndex = {configItem.ServiceIndex}");
             if (configItem.Version != null)
                 configurationOutput.AppendLine($"        Version = {configItem.Version}");
+            configurationOutput.AppendLine($"        PreferredPackagePrefixes = {string.Join(", ", configItem.PreferredPackagePrefixes)}");
+            configurationOutput.AppendLine($"        DeniedPackagePrefixes = {string.Join(", ", configItem.DeniedPackagePrefixes)}");
 
         }
         

--- a/src/Westermo.Nuget.ReadThroughCache/Services/V2/IRemotePackageRepository.cs
+++ b/src/Westermo.Nuget.ReadThroughCache/Services/V2/IRemotePackageRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -9,6 +10,8 @@ public interface IRemotePackageRepository
 {
     string Name { get; }
     Uri ServiceIndex { get; }
+    Regex[] PreferredPackagePrefixes { get; } 
+    Regex[] DeniedPackagePrefixes { get; } 
     
     Task<XDocument?> GetPackageInformation(string packageId, string? semVerLevel, CancellationToken cancellationToken);
 }

--- a/src/Westermo.Nuget.ReadThroughCache/Services/V2/RemotePackageRepository.cs
+++ b/src/Westermo.Nuget.ReadThroughCache/Services/V2/RemotePackageRepository.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Net;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
@@ -17,12 +18,16 @@ public class RemotePackageRepository : IRemotePackageRepository
     public RemotePackageRepository(IHttpClient httpClient,
                                    string name,
                                    Uri serviceIndex,
+                                   Regex[] preferredPackagePrefixes,
+                                   Regex[] deniedPackagePrefixes,
                                    ILogger<RemotePackageRepository> logger)
     {
         m_httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         m_logger = logger ?? throw new ArgumentNullException(nameof(logger));
         Name = name ?? throw new ArgumentNullException(nameof(name));
         ServiceIndex = serviceIndex ?? throw new ArgumentNullException(nameof(serviceIndex));
+        PreferredPackagePrefixes = preferredPackagePrefixes ?? throw new ArgumentNullException(nameof(preferredPackagePrefixes));
+        DeniedPackagePrefixes = deniedPackagePrefixes ?? throw new ArgumentNullException(nameof(deniedPackagePrefixes));
     }
 
     private static readonly XNamespace s_nsAtom = XNamespace.Get("http://www.w3.org/2005/Atom");
@@ -54,4 +59,6 @@ public class RemotePackageRepository : IRemotePackageRepository
 
     public string Name { get; }
     public Uri ServiceIndex { get; }
+    public Regex[] PreferredPackagePrefixes { get; }
+    public Regex[] DeniedPackagePrefixes { get; }
 }

--- a/src/Westermo.Nuget.ReadThroughCache/Services/V2/RemotePackageRepositoryCollection.cs
+++ b/src/Westermo.Nuget.ReadThroughCache/Services/V2/RemotePackageRepositoryCollection.cs
@@ -32,7 +32,15 @@ public class RemotePackageRepositoryCollection : IRemotePackageRepositoryCollect
         configuration.Bind("PackageRepositories", configItems);
 
         m_remotePackageRepositories = configItems.Where(item => item.Version == 2)
-                                                 .Select(item => new RemotePackageRepository(httpClient, item.Name, new Uri(item.ServiceIndex, UriKind.Absolute), m_logger))
+                                                 .Select(item => new RemotePackageRepository(
+                                                             httpClient,
+                                                             item.Name,
+                                                             new Uri(item.ServiceIndex, UriKind.Absolute),
+                                                             item.PreferredPackagePrefixesAsRegex,
+                                                             item.DeniedPackagePrefixesAsRegex,
+                                                             m_logger
+                                                         )
+                                                  )
                                                  .Cast<IRemotePackageRepository>()
                                                  .ToImmutableArray();
     }

--- a/src/Westermo.Nuget.ReadThroughCache/Services/V3/IRemotePackageRepository.cs
+++ b/src/Westermo.Nuget.ReadThroughCache/Services/V3/IRemotePackageRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 
 namespace Westermo.Nuget.ReadThroughCache.Services.V3;
 
@@ -6,4 +7,6 @@ public interface IRemotePackageRepository : IPackageRepository
 {
     string Name { get; }
     Uri ServiceIndex { get; }
+    Regex[] PreferredPackagePrefixes { get; } 
+    Regex[] DeniedPackagePrefixes { get; }
 }

--- a/src/Westermo.Nuget.ReadThroughCache/Services/V3/RemotePackageRepository.cs
+++ b/src/Westermo.Nuget.ReadThroughCache/Services/V3/RemotePackageRepository.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNext.Threading;
@@ -25,12 +26,16 @@ public class RemotePackageRepository : IRemotePackageRepository
                                    IHttpClient httpClient,
                                    ILogger<RemotePackageRepository> logger,
                                    string name,
+                                   Regex[] preferredPackagePrefixes,
+                                   Regex[] deniedPackagePrefixes,
                                    Uri serviceIndex)
     {
         m_clock = clock ?? throw new ArgumentNullException(nameof(clock));
         m_httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         m_logger = logger ?? throw new ArgumentNullException(nameof(logger));
         Name = name ?? throw new ArgumentNullException(nameof(name));
+        PreferredPackagePrefixes = preferredPackagePrefixes ?? throw new ArgumentNullException(nameof(preferredPackagePrefixes));
+        DeniedPackagePrefixes = deniedPackagePrefixes ?? throw new ArgumentNullException(nameof(deniedPackagePrefixes));
         ServiceIndex = serviceIndex ?? throw new ArgumentNullException(nameof(serviceIndex));
 
         m_serviceIndexValues = new AsyncLazy<ServiceIndexWithTimestamp>(async cancellationToken =>
@@ -164,5 +169,7 @@ public class RemotePackageRepository : IRemotePackageRepository
     }
 
     public string Name { get; }
+    public Regex[] PreferredPackagePrefixes { get; }
+    public Regex[] DeniedPackagePrefixes { get; }
     public Uri ServiceIndex { get; }
 }

--- a/src/Westermo.Nuget.ReadThroughCache/Services/V3/RemotePackageRepositoryCollection.cs
+++ b/src/Westermo.Nuget.ReadThroughCache/Services/V3/RemotePackageRepositoryCollection.cs
@@ -30,7 +30,16 @@ public class RemotePackageRepositoryCollection : IRemotePackageRepositoryCollect
         configuration.Bind("PackageRepositories", configItems);
 
         m_remotePackageRepositories = configItems.Where(item => item.Version == 3)
-                                                 .Select(item => new RemotePackageRepository(clock, httpClient, logger, item.Name, new Uri(item.ServiceIndex, UriKind.Absolute)))
+                                                 .Select(item => new RemotePackageRepository(
+                                                             clock,
+                                                             httpClient,
+                                                             logger,
+                                                             item.Name,
+                                                             item.PreferredPackagePrefixesAsRegex,
+                                                             item.DeniedPackagePrefixesAsRegex,
+                                                             new Uri(item.ServiceIndex, UriKind.Absolute)
+                                                         )
+                                                  )
                                                  .Cast<IRemotePackageRepository>()
                                                  .ToImmutableArray();
     }

--- a/src/Westermo.Nuget.ReadThroughCache/appsettings.Development.json
+++ b/src/Westermo.Nuget.ReadThroughCache/appsettings.Development.json
@@ -7,12 +7,5 @@
     },
     "UriBaseForV2Urls": "http://localhost:5000/v2/",
     "PackageCacheRootDirectory": "/tmp/package-cache-root",
-    "PackageRepositories": [
-        {
-            "Name": "nuget.org",
-            "ServiceIndex": "https://api.nuget.org/v3/index.json",
-            "Version": 3
-        }
-    ],
     "FeedFile": "appsettings.nuget-feed.json"
 }

--- a/src/Westermo.Nuget.ReadThroughCache/appsettings.nuget-feed.json
+++ b/src/Westermo.Nuget.ReadThroughCache/appsettings.nuget-feed.json
@@ -3,7 +3,8 @@
         {
             "Name": "nuget.org",
             "ServiceIndex": "https://api.nuget.org/v3/index.json",
-            "Version": 3
+            "Version": 3,
+            "DeniedPackagePrefixes": ["^DevExpress"]
         }
     ]
 }


### PR DESCRIPTION
Added parameters for preferred package prefixes and denied package prefixes. These parameters control the usage of the remote repositories.

The prefixes are actually not prefixes per se: they are regular expressions, so they may match on any pattern expressible by .NET regular expressions. The compiled regular expressions are case insensitive.